### PR TITLE
Added the check_header_parser flag to read_fasta

### DIFF
--- a/protfasta/__init__.py
+++ b/protfasta/__init__.py
@@ -29,6 +29,7 @@ def _get_data(path):
 def read_fasta(filename, 
                expect_unique_header=True,
                header_parser=None,
+               check_header_parser=True,
                duplicate_sequence_action='ignore',
                duplicate_record_action='fail',
                invalid_sequence_action='fail',
@@ -92,9 +93,13 @@ def read_fasta(filename,
         whatever it returns will be used as the actual header as the files are parsed. This can be useful if you 
         know your FASTA header has a consistent format that you want to take advantage of. A function provided here MUST        
         **(1)** Take a single input argument (the header string) and **(2)** Return a single string.
-        When parsing this function the following test is applied
+        When parsing this function the following test is applied, unless ``check_header_parser`` is set to false.
             >>> return_string = header_parser('this test string should work')
-        Where ``return_string`` is tested to be a string. The function will show an exception if this test fails.
+        Where ``return_string`` is tested to be a string. The function will show an exception if this test fails and ``check_header_parser`` is set to true.
+
+    check_header_parser : bool
+        [**Default = True**] Flag which - if set to false - will not test if the header_parser function returns a valid string. 
+        This may lead to unexpected header values if the passed header_parser function is not well defined.
         
     duplicate_record_action : ``'ignore'``, ``'fail'``, ``'remove'``
         [**Default = 'fail'**] Selector that determines how to deal with duplicate entries. Note that duplicate records refers to
@@ -176,6 +181,7 @@ def read_fasta(filename,
     # keywords MUST be sanity checked in this function
     _io.check_inputs(expect_unique_header,
                      header_parser, 
+                     check_header_parser,
                      duplicate_record_action,
                      duplicate_sequence_action,
                      invalid_sequence_action, 

--- a/protfasta/io.py
+++ b/protfasta/io.py
@@ -21,6 +21,7 @@ from .protfasta_exceptions import ProtfastaException
 
 def check_inputs(expect_unique_header, 
                  header_parser, 
+                 check_header_parser,
                  duplicate_record_action, 
                  duplicate_sequence_action,
                  invalid_sequence_action, 
@@ -44,6 +45,9 @@ def check_inputs(expect_unique_header,
     header_parser : ?
         Checks it's a callable function that returns a single string (and takes a single
         string as the input argument)
+
+    check_header_parser : ?
+        Flag to turn on/off checking of header_parser
 
     duplicate_record_action : ?
         Checks its a string that matches one of a specific set of keywords
@@ -80,17 +84,18 @@ def check_inputs(expect_unique_header,
     if type(expect_unique_header) != bool:
         raise ProtfastaException("keyword 'expect_unique_header' must be a boolean")
 
-    # validate the header_parser 
-    if header_parser is not None:
-        if not callable(header_parser):
-            raise ProtfastaException("keyword 'header_parser' must be a function [tested with callable()]")
-        
-        try:
-            a = header_parser('this test string should work')
-            if type(a) != str:
-                raise ProtfastaException('Something went wrong when testing the header_parser function.\nFunction completed but return value was not a string')
-        except Exception as e:
-            raise ProtfastaException('Something went wrong when testing the header_parser function.\nException: %s'%str(e))
+    # validate the header_parser
+    if check_header_parser:
+        if header_parser is not None:
+            if not callable(header_parser):
+                raise ProtfastaException("keyword 'header_parser' must be a function [tested with callable()]")
+            
+            try:
+                a = header_parser('this test string should work')
+                if type(a) != str:
+                    raise ProtfastaException('Something went wrong when testing the header_parser function.\nFunction completed but return value was not a string')
+            except Exception as e:
+                raise ProtfastaException('Something went wrong when testing the header_parser function.\nException: %s'%str(e))
             
 
     # check the duplicates_record_action 


### PR DESCRIPTION
Added the "check_header_parser" boolean flag to "read_fasta"

The reason behind this is that most of the time, proteome fasta files from Uniprot are formatted such that advanced parser rules can capture all cases but the "this test string" test is incompatible with them. e.g. >sp|P00000|GENE_ORG & >sp|AXA000000|GENE_ORG can be parsed by splitting on "|" and then taking the second element of the list to return the strings "P00000" and "AXA000000", respectively.

The default is set to True to not modify the original behavior of "read_fasta" or the "header_parser" argument. This feature is meant as a power-user feature, which we have come to appreciate and perhaps others will too. 